### PR TITLE
Create GitHub Workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    paths:
+      - '**.json'
+      - '**.js'
+      - '**.ts'
+  push:
+    branches:
+      - main
+
+jobs:
+  eslint:
+    name: ESLint Checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Node v18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npx eslint --ext .ts web/ traffic/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,34 @@
+name: Publish Package
+
+on:
+  workflow_dispatch:
+  release:
+    types: [created]
+
+jobs:
+  publish_npmjs:
+    name: Publish Package to npmjs
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'TruckersMP'
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v3
+
+      - name: Install Node v18
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: npm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Create two GitHub workflows:

- Continuos integration. Runs automatic checks/tests to ensure nothing has got broken.
- Publish. Automatically publishes a package to the npmjs registry.
  This can be invoked manually, or is run automatically on a tag creation.