### PR TITLE
Add a new Steam ID property to APICompanyMember.

### DIFF
--- a/web/v2/company.ts
+++ b/web/v2/company.ts
@@ -315,6 +315,11 @@ export interface APICompanyMember {
   steam_id: bigint;
 
   /**
+   * The member's Steam ID.
+   */
+  steamID: string;
+
+  /**
    * The member's role ID.
    */
   role_id: number;


### PR DESCRIPTION
The new field is provided as a string, ensuring full compatibility on systems where a (big) integer might be an issue.

- https://github.com/TruckersMP/API-Documentation/pull/11