### PR TITLE
add missing leading slash for companyEventsAttending

### DIFF
--- a/web/v2/index.ts
+++ b/web/v2/index.ts
@@ -64,7 +64,7 @@ export const APIWebRoutes = {
    * @returns APIResponse<APIGameEventSimple[]>
    */
   companyEventsAttending(companyId: number | string) {
-    return `vtc/${companyId}/events/attending` as const;
+    return `/vtc/${companyId}/events/attending` as const;
   },
 
   /**


### PR DESCRIPTION
This pull request adds a missing leading slash in the returned value of companyEventsAttending()

This does not cause issues with Axios however it is inconsistent and might bring issues for those who do not use Axios as their http library.